### PR TITLE
fix: increase z index score of nav bar

### DIFF
--- a/client/src/components/Navbar.tsx
+++ b/client/src/components/Navbar.tsx
@@ -36,7 +36,7 @@ export default function Navbar() {
   const [toggleMenu, setToggleMenu] = useState(false);
 
   return (
-    <nav className="flex justify-between items-center pr-4 sm:px-4 lg:px-12 border-b-4 border-main-blue relative">
+    <nav className="flex justify-between items-center pr-4 sm:px-4 lg:px-12 border-b-4 border-main-blue relative z-50">
       <NavLink to="/">
         <img
           src={logo}


### PR DESCRIPTION
Made navbar z-index to 50 as home page hero section text was overlapping the navbar on mobile devices.